### PR TITLE
replaced -n with ! when evaluating grep exit code

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,7 @@ mkdir -p "$HOME/.ssh"
 cp aws-ssm-ec2-proxy-command.sh "$HOME/.ssh/aws-ssm-ec2-proxy-command.sh"
 chmod +x "$HOME/.ssh/aws-ssm-ec2-proxy-command.sh"
 
-if [[ -n $(grep -q 'host i-*' "$HOME/.ssh/config") ]]; then
+if [[ ! $(grep -q 'host i-*' "$HOME/.ssh/config") ]]; then
   cat <<EOF >>~/.ssh/config
 host i-* mi-*
   IdentityFile ~/.ssh/id_rsa


### PR DESCRIPTION
Ran into this issue when trying to run install script from Ubuntu image. 
Replacing -n with ! fixed the issue for me. Something to do with the exit code/status code returned from grep.